### PR TITLE
Handling case where there is only one page of tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,8 +40,13 @@ var GithubTags   = function() {
 };
 
 var getLastPageNo = function(page) {
-  var lastPageUrl = parseLinks(page.tags.meta.link).last;
-  var lastPageNo  = url.parse(lastPageUrl, true).query.page;
+  var lastPageUrl;
+  var lastPageNo = page.no;
+  if (typeof(page.tags.meta.link) !== 'undefined') {
+    lastPageUrl = parseLinks(page.tags.meta.link).last;
+    lastPageNo  = url.parse(lastPageUrl, true).query.page;
+  }
+  
   return lastPageNo;
 };
 


### PR DESCRIPTION
Updated getLastPageNo function to just use the page.no attribute if the page.tags.meta.link item is undefeind.
